### PR TITLE
Updated device mapper for poller + instructions updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ If you are using another distribution, you will need the following packages:
 * redis-server
 * monit
 
+--
+
+**Ubuntu 18.04 is not recommended, but in case you've crossed the rubicon and you're commited, follow the instructions below to get the poller working.** 
+
+Add the following lines to `/etc/apt/sources.list`
+
+`deb http://security.ubuntu.com/ubuntu xenial-security main universe`
+`deb http://security.ubuntu.com/ubuntu xenial-security main` 
+
+Then run 
+
+`apt-get update`
+`sudo apt-get install php7.0-cli php7.0-zip php7.0-snmp php7.0-sqlite3 php7.0-bcmath php7.0-mbstring php7.0-dom`
+
+If you have issues, try installing the older version of redis, as the predis library is reported to have issues with newer versions.
+
+`wget  http://security.ubuntu.com/ubuntu/pool/universe/r/redis/redis-server_3.0.6-1ubuntu0.4_amd64.deb`
+`dpkg -i redis-server_3.0.6-1ubuntu0.4_amd64.deb` 
+
+
+--
+
 Once the packages are installed, we can install the poller. First, download the latest poller code by typing `git clone https://github.com/SonarSoftware/poller.git`. This will clone the existing code into a directory named `poller`, enter it by typing `cd poller`. Now, navigate to the [releases](https://github.com/SonarSoftware/poller/releases) page and check what the latest tagged release is. You can also type
 `git describe --abbrev=0` to see the latest tag from the command line. Once you've found it, type `git checkout tags/{TAG}` where `{TAG}` is the latest tag found (e.g. `git checkout tags/1.0.3`). Now type `php install.php` and the installer will setup the poller itself.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you are using another distribution, you will need the following packages:
 
 --
 
-**Ubuntu 18.04 is not recommended, but in case you've crossed the rubicon and you're committed, follow the instructions below to get the poller working.** 
+**Ubuntu 18.04 is not recommended, if you can't use Ubuntu 16.04 for whatever reasons, please follow the instructions below to get the poller working.** 
 
 Note: if you've already installed the newer flavour of these programs, you will need to remove them or start on a fresh image.
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ If you are using another distribution, you will need the following packages:
 
 --
 
-**Ubuntu 18.04 is not recommended, but in case you've crossed the rubicon and you're commited, follow the instructions below to get the poller working.** 
+**Ubuntu 18.04 is not recommended, but in case you've crossed the rubicon and you're committed, follow the instructions below to get the poller working.** 
 
 Add the following lines to `/etc/apt/sources.list`
 
 `deb http://security.ubuntu.com/ubuntu xenial-security main universe`
+
 `deb http://security.ubuntu.com/ubuntu xenial-security main` 
 
 Then run 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then run
 If you have issues, try installing the older version of redis, as the predis library is reported to have issues with newer versions.
 
 `wget  http://security.ubuntu.com/ubuntu/pool/universe/r/redis/redis-server_3.0.6-1ubuntu0.4_amd64.deb`
+
 `dpkg -i redis-server_3.0.6-1ubuntu0.4_amd64.deb` 
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ If you are using another distribution, you will need the following packages:
 
 **Ubuntu 18.04 is not recommended, but in case you've crossed the rubicon and you're committed, follow the instructions below to get the poller working.** 
 
+Note: if you've already installed the newer flavour of these programs, you will need to remove them or start on a fresh image.
+
 Add the following lines to `/etc/apt/sources.list`
 
 `deb http://security.ubuntu.com/ubuntu xenial-security main universe`

--- a/src/Pollers/DeviceMappingPoller.php
+++ b/src/Pollers/DeviceMappingPoller.php
@@ -154,63 +154,106 @@ class DeviceMappingPoller
      */
     private function getDeviceMapper(array $hostWithDeviceType, Device $device)
     {
-        switch ($hostWithDeviceType['type_query_result'])
-        {
-            case "1.3.6.1.4.1.161.19.250.256":
+        $oidToMapper = [
+            "1.3.6.1.4.1.161" => "CANOPY",
+            "1.3.6.1.4.1.2736.1.1" => "ETHERWAN",
+            "1.3.6.1.4.1.10002.1" => "UBNT",
+            "1.3.6.1.4.1.14988.1" => "MIKROTIK",
+            "1.3.6.1.4.1.17713.5" => "CAMBIUMPTP500",
+            "1.3.6.1.4.1.17713.6" => "CAMBIUMPTP600",
+            "1.3.6.1.4.1.17713.7" => "CAMBIUMPTP650",
+            "1.3.6.1.4.1.17713.8" => "CAMBIUMPTP800",
+            "1.3.6.1.4.1.17713.9" => "CAMBIUMPTP700",
+            "1.3.6.1.4.1.17713.11" => "CAMBIUMPTP670",
+            "1.3.6.1.4.1.17713.21" => "CAMBIUMEPMP",
+            "1.3.6.1.4.1.17713.250" => "CAMBIUMPTP250",
+            "1.3.6.1.4.1.41112.1.4" => "UBNTAIRMAX",
+            "1.3.6.1.4.1.43356.1.1.1" => "MIMOSABX",
+            "1.3.6.1.4.1.43356.1.1.2" => "MIMOSABX",
+            "1.3.6.1.4.1.43356.1.1.3" => "MIMOSAAX",
+        ];
+
+        $longestOid = 0;
+        $m = "GENERIC";
+
+        foreach ($oidToMapper as $enumeration => $mapperName) {
+            if (strpos($hostWithDeviceType['type_query_result'], $enumeration) !== false) {
+                // initial state, found a match
+                if ($longestOid === 0) {
+                    $longestOid = strlen($enumeration);
+                    $m = $mapperName;
+		    
+                    if (getenv('DEBUG') == "true") {
+	   	                $this->log->log("initial state, ip: ".$hostWithDeviceType['ip'] . " enumeration is " . $enumeration . "... best mapper is: " . $m, Logger::DEBUG);
+                    }
+                }
+                // updated state, found a better match
+                if (strlen($enumeration) > $longestOid) {
+                    $longestOid = strlen($enumeration);
+                    $m = $mapperName;
+                    if (getenv('DEBUG') == "true") {
+                        $this->log->log("update state, ip: ".$hostWithDeviceType['ip'] . " enumeration is " . $enumeration . "... best mapper is: " . $m, Logger::DEBUG);
+                    }
+                }
+
+            }
+        }
+
+        switch ($m) {
+            case "CANOPY":
                 $mapper = new CambiumCanopyPMPAccessPointMapper($device);
                 break;
-            case "1.3.6.1.4.1.17713.21":
-            case "1.3.6.1.4.1.17713.21.1.1.2":
+            case "CAMBIUMEPMP":
                 $mapper = new CambiumEpmpAccessPointMapper($device);
                 break;
-            case "1.3.6.1.4.1.41112.1.4":
+            case "UBNTAIRMAX":
                 $mapper = new UbiquitiAirMaxAccessPointMapper($device);
                 break;
-            case "1.3.6.1.4.1.17713.7":
+            case "CAMBIUMPTP650":
                 $mapper = new CambiumPTP650Backhaul($device);
                 break;
-            case "1.3.6.1.4.1.17713.6":
+            case "CAMBIUMPTP600":
                 $mapper = new CambiumPTP600Backhaul($device);
                 break;
-            case "1.3.6.1.4.1.17713.250":
+            case "CAMBIUMPTP250":
                 $mapper = new CambiumPTP250Backhaul($device);
                 break;
-            case "1.3.6.1.4.1.17713.5":
+            case "CAMBIUMPTP500":
                 $mapper = new CambiumPTP500Backhaul($device);
                 break;
-            case "1.3.6.1.4.1.17713.11":
+            case "CAMBIUMPTP670":
                 $mapper = new CambiumPTP670Backhaul($device);
                 break;
-            case "1.3.6.1.4.1.17713.9":
+            case "CAMBIUMPTP700":
                 $mapper = new CambiumPTP700Backhaul($device);
                 break;
-            case "1.3.6.1.4.1.17713.8":
+            case "CAMBIUMPTP800":
                 $mapper = new CambiumPTP800Backhaul($device);
                 break;
-            case "1.3.6.1.4.1.10002.1":
+            case "UBNT":
                 $identifier = new UbiquitiIdentifier($device);
                 $mapper = $identifier->getMapper(); //Ubiquiti doesn't separate their devices well by sysObjectID. This identifier will attempt to determine the right device to return.
                 break;
-            case "1.3.6.1.4.1.43356.1.1.1": //B5, B5c, B11, B5-Lite (FW 1.4.5 and older)
-            case "1.3.6.1.4.1.43356.1.1.2": //B5-Lite
+            case "MIMOSABX":
                 $mapper = new MimosaBxBackhaul($device);
                 break;
-            case "1.3.6.1.4.1.43356.1.1.3": //A5-14, A5-18, A5c (FW 2.3+)
+            case "MIMOSAAX": //A5-14, A5-18, A5c (FW 2.3+)
                 $mapper = new MimosaAxAccessPoint($device);
                 break;
-            case "1.3.6.1.4.1.2736.1.1":
+            case "ETHERWAN":
                 $mapper = new EtherwanSwitch($device);
                 break;
-            case "1.3.6.1.4.1.14988.1":
+            case "MIKROTIK":
                 $mapper = new MikroTik($device);
                 break;
+            case "GENERIC":
             default:
                 $mapper = new GenericDeviceMapper($device, $hostWithDeviceType['type'] == 'network_sites');
                 break;
         }
 
         return $mapper;
-    }
+}
 
     /**
      * Determine the type of a device and return it to the caller for further processing


### PR DESCRIPTION
The new device-mapper now matches the sysObjectID string against the longest valid OID in the oid->mapper switch case list.. if a device mapper is not found, it's assigned generic.
